### PR TITLE
Make the main logo a link to the homepage and correct alt-text typo

### DIFF
--- a/frontend/components/base/Navbar.tsx
+++ b/frontend/components/base/Navbar.tsx
@@ -64,11 +64,18 @@ const LeftMenu = styled.div`
   align-self: center;
 `
 
-const LogoImage = styled.img`
+const Logo = styled.a`
   grid-column: 2;
-  max-height: 21px;
   align-self: center;
+  
+  display: flex:
+  align-items: center;
+
+  img {
+    max-height: 21px;
+  }
 `
+
 function Navbar() {
   const [isActive, setIsActive] = useState(false)
   function handleClick() {
@@ -93,7 +100,13 @@ function Navbar() {
               <a href="#">Opinion</a>
             </Link>
           </LeftMenu>
-          <LogoImage src="/logo.svg" alt="the Amherst Student" />
+          <Link href="/">
+            <Logo>
+              <a href="#">
+                <img src="/logo.svg" alt="The Amherst Student" />
+              </a>
+            </Logo>
+          </Link>
           <Socials>
             <li>
               <a href="https://www.facebook.com/AmherstStudent/">


### PR DESCRIPTION
- The logo image is now wrapped in a "Link" and an "a" tag, which allows it to link to the homepage.
- In order to retain the vertical centering of the logo image, the "img" is centered with flexbox.
- This change changes the name of the styled-component from LogoImage to Logo, as it is no longer only a styled "img".
- The image's alt-text was changed from "the Amherst Student" to "The Amherst Student".

If there is a more ideal way to implement this change, I would be very happy to make alterations.

Thank you!