### PR TITLE
Fix wrong href link for Sports page in Navbar

### DIFF
--- a/frontend/components/base/Navbar.tsx
+++ b/frontend/components/base/Navbar.tsx
@@ -86,7 +86,7 @@ function Navbar() {
             <Link href="/section/arts-and-living">
               <a href="#">Arts and Living</a>
             </Link>
-            <Link href="/section/news">
+            <Link href="/section/sports">
               <a href="#">Sports</a>
             </Link>
             <Link href="/section/opinion">


### PR DESCRIPTION
In the Navbar, the link to the Sports page incorrectly links to the News page. This change corrects the issue.